### PR TITLE
Fixed not found issue when urls end with slash and rout have no slash

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -264,7 +264,11 @@ class Route
         if (! $this->routable) {
             return false;
         }
-        
+
+        //  trim the last slash of path
+        $path           = rtrim($path,'/');
+        //  trim the last slash of regex
+        $this->regex    = rtrim($this->regex,'/');
         $is_match = preg_match("#^{$this->regex}$#", $path, $this->matches)
                  && $this->isMethodMatch($server)
                  && $this->isSecureMatch($server)


### PR DESCRIPTION
Hi
Hi have done a small fix in Rout.php. Just changed the sensitive way of rout matching. If the url end with slash and corresponding rout have no slash (and vice versa), it will end up in 404. Here i just trimmed down the last slash of both path and regex.
(NB: I am new to aura. Please let me know if done something wrong)
