### PR TITLE
Use the 'old' syntax for named subpatterns (compatible with PCRE <= v6.6)

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -358,7 +358,7 @@ class Route
                     throw new Exception($message);
                 } else {
                     $keys[] = "{:$name}";
-                    $vals[] = "(?<$name>" . substr($subpattern, 1);
+                    $vals[] = "(?P<$name>" . substr($subpattern, 1);
                 }
             }
             $this->regex = str_replace($keys, $vals, $this->regex);


### PR DESCRIPTION
The documentation[1] on php.net is not very clear about the fact that the syntax depends on the PCRE library. We use a recent version op PHP (5.3.6), but CentOS ships with PCRE 6.6...

[1] http://www.php.net/manual/en/function.preg-match.php
