### PR TITLE
fix misnamed routes

### DIFF
--- a/src/Aura/Router/Map.php
+++ b/src/Aura/Router/Map.php
@@ -346,6 +346,9 @@ class Map
         $this->attach_routes = $spec['routes'];
         unset($spec['routes']);
 
+        // reset the internal pointer of the array to avoid misnamed routes
+        reset($this->attach_routes);
+
         // ... and the remaining common information
         $this->attach_common = $spec;
 


### PR DESCRIPTION
Hi,

I've found that some of my routes had the same name after being processed by the \Aura\Router\Map class.
It appears that it was the internal pointer of the "attached_routes" property array that was not placed at the beginning of the array.
So, I've added the "reset" line to make sure that the pointer is well placed after the property has been set.

Thanks.
