### PR TITLE
Update Route.php to allow attach with empty path

### DIFF
--- a/src/Aura/Router/Route.php
+++ b/src/Aura/Router/Route.php
@@ -226,14 +226,14 @@ class Route
 
         // set the path, with prefix if needed
         $this->path_prefix = (string) $path_prefix;
-        if ($path_prefix && $path && strpos($path, '://') === false) {
+        if ($path_prefix && strpos($path, '://') === false) {
             // concat the prefix and path
             $this->path = (string) $path_prefix . $path;
             // convert all // to /, so that prefixes ending with / do not mess
             // with paths starting with /
             $this->path = str_replace('//', '/', $this->path);
         } else {
-            // no path prefix, or no path, or path has :// in it
+            // no path prefix, or path has :// in it
             $this->path = (string) $path;
         }
 


### PR DESCRIPTION
In my app I need to be able to serve both "http://localhost/blog" as well as "http://localhost/blog/".

I want to use "$router->attach()" to group my routes together.

However, I discovered that this only allows me to match "http://localhost/blog/", with a trailing slash. If I try entering a path of "" to match without the trailing slash then the path_prefix is completely ignored and the route entry is left blank.

This goes against the concept that all routes in the "attach" group will have the path_prefix added.

With this modification, it will match on the route so for instance $router->attach('/blog', [ 'routes' => [ 'browse' => '' ] ]); will allow the route '/blog' to be matched.

This also eliminates the argument in a different pull request whether a route should or should not end with a trailing slash, as the developer can more easily implement both without affecting existing implementations, and keep it all within a single attach.
