### PR TITLE
Implemented bracketed optional parameters

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -312,9 +312,9 @@ class Route extends AbstractSpec
         // ex: [/{language}] or [.{type}]
         preg_match_all('#\[([^\[{}])*({[^\[\[]+})+\]#', $this->regex, $matches);
         if (isset($matches[0]) && !empty($matches[0])) {
-            $this->regexOptionalParams = [];
+            $this->regexOptionalParams = array();
             // replacements for the regex
-            $replacements = [];
+            $replacements = array();
             foreach (array_keys($matches[0]) as $index) {
                 $replacement = '(';
                 // this is the prefix before the parameter

--- a/src/Route.php
+++ b/src/Route.php
@@ -63,7 +63,18 @@ class Route extends AbstractSpec
     protected $regex;
 
     /**
-     * 
+     *
+     * The optional params that are defined with brackets.
+     * These params are cached for performance reasons (when using the generate() method)
+     *
+     * @var array
+     *
+     */
+    protected $regexOptionalParams = array();
+
+
+    /**
+     *
      * All params found during the `isMatch()` process, both from the path
      * tokens and from matched server values.
      * 
@@ -160,7 +171,7 @@ class Route extends AbstractSpec
         if (! $this->regex) {
             $this->setRegex();
         }
-        
+
         // check matches
         $is_match = $this->isRegexMatch($path)
                  && $this->isServerMatch($server)
@@ -215,7 +226,19 @@ class Route extends AbstractSpec
                 $repl["{{$key}}"] = rawurlencode($val);
             }
         }
-        
+
+        // replacements for bracketed optional parameters
+        foreach ($this->regexOptionalParams as $param => $bracketedString) {
+            // if the parameter has the default value,
+            // remove its corresponding part from the link
+            if ($data[$param] == $this->values[$param]) {
+                $link = str_replace($bracketedString, '', $link);
+            // otherwise, remove the brackets
+            } else {
+                $link = str_replace($bracketedString, trim($bracketedString, '[]'), $link);
+            }
+        }
+
         // replacements for optional params, if any
         preg_match('#{/([a-z][a-zA-Z0-9_,]*)}#', $link, $matches);
         if ($matches) {
@@ -242,7 +265,7 @@ class Route extends AbstractSpec
         
         // replace params in the link, including optional params
         $link = strtr($link, $repl);
-        
+
         // add wildcard data
         $wildcard = $this->spec['wildcard'];
         if ($wildcard && isset($data[$wildcard])) {
@@ -285,6 +308,26 @@ class Route extends AbstractSpec
      */
     protected function setRegexOptionalParams()
     {
+        // optional parameters that use brackets
+        // ex: [/{language}] or [.{type}]
+        preg_match_all('#\[([^\[{}])*({[^\[\[]+})+\]#', $this->regex, $matches);
+        if (isset($matches[0]) && !empty($matches[0])) {
+            $this->regexOptionalParams = [];
+            // replacements for the regex
+            $replacements = [];
+            foreach (array_keys($matches[0]) as $index) {
+                $replacement = '(';
+                // this is the prefix before the parameter
+                $replacement .= $matches[1][$index] ? preg_quote($matches[1][$index], '/') : '';
+                $replacement .= $matches[2][$index];
+                $replacement .= ')?';
+                $replacements[$matches[0][$index]] = $replacement;
+                // cache the optional params
+                $this->regexOptionalParams[trim($matches[2][$index], '{}')] = $matches[0][$index];
+            }
+            $this->regex = strtr($this->regex, $replacements);
+        }
+
         preg_match('#{/([a-z][a-zA-Z0-9_,]*)}#', $this->regex, $matches);
         if (! $matches) {
             return;

--- a/tests/src/RouteTest.php
+++ b/tests/src/RouteTest.php
@@ -625,12 +625,12 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($foo->isMatch('/blog/archive/2014/01', array()));
 
         $this->assertEquals(
-            [
+            array(
                 'language' => 'en',
                 'type' => 'html',
                 'year' => '2014',
                 'month' => '01',
-            ],
+            ),
             $foo->params);
 
         // test generate with default language

--- a/tests/src/RouteTest.php
+++ b/tests/src/RouteTest.php
@@ -608,4 +608,37 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $actual = $route->isMatch('/foo/bar/baz', $this->server);
         $this->assertTrue($actual);
     }
+
+    public function testOptionalTokens() {
+        $foo = $this->factory->newInstance('[/{language}]/blog/archive[/{year}][/{month}][.{type}]')
+            ->addTokens(array(
+                'language' => '[a-z]{0,2}',
+                'year' => '\d+',
+                'month' => '\d+',
+            ))
+            ->addValues(array(
+                'language' => 'en',
+                'type' => 'html'
+            ));
+
+        $this->assertTrue($foo->isMatch('/fr/blog/archive/2014/01', array()));
+        $this->assertTrue($foo->isMatch('/blog/archive/2014/01', array()));
+
+        $this->assertEquals(
+            [
+                'language' => 'en',
+                'type' => 'html',
+                'year' => '2014',
+                'month' => '01',
+            ],
+            $foo->params);
+
+        // test generate with default language
+        $url = $foo->generate(array('languge' => 'en', 'type' => 'xml', 'year' => 2014));
+        $this->assertEquals('/blog/archive/2014.xml', $url);
+
+        // test generate with default type
+        $url = $foo->generate(array('language' => 'fr', 'type' => 'html', 'year' => 2014));
+        $this->assertEquals('/fr/blog/archive/2014', $url);
+    }
 }

--- a/tests/src/RouterTest.php
+++ b/tests/src/RouterTest.php
@@ -471,4 +471,5 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Aura\Router\Exception\UnexpectedValue');
         $this->router->offsetSet('bar', 'not a route');
     }
+
 }


### PR DESCRIPTION
This allows one to create routes like
- `[/{language}]/pages[.{type}]` which will match `/pages` and `/en/pages` and `/en/pages.json`
- `posts/archive[/{year}][/{month}][/{day}]`

The `generate()` method makes sure that parameters that have the default value are not included. So, if the `language` default value is **en** the URL that will be generated will NOT start with **/en**
