### PR TITLE
allow "accept" conditions, and separate "method" condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,22 +689,22 @@ param to dispatch it.
 <?php
 $router->add('read', '/blog/read/{id}{format}')
     ->addTokens(array(
-		'id' => '\d+',
+        'id' => '\d+',
         'format' => '(\.[^/]+)?',
-	))
-	->addValues(array(
-		'action' => function ($params) {
-		    if ($params['format'] == '.json') {
-    			$id = (int) $params['id'];
-		        header('Content-Type: application/json');
-		        echo json_encode(['id' => $id]);
-		    } else {
-    			$id = (int) $params['id'];
-		        header('Content-Type: text/plain');
-    			echo "Reading blog ID {$id}";
-		    }
-		},
-		'format' => '.html',
+    ))
+    ->addValues(array(
+        'action' => function ($params) {
+            if ($params['format'] == '.json') {
+                $id = (int) $params['id'];
+                header('Content-Type: application/json');
+                echo json_encode(['id' => $id]);
+            } else {
+                $id = (int) $params['id'];
+                header('Content-Type: text/plain');
+                echo "Reading blog ID {$id}";
+            }
+        },
+        'format' => '.html',
     ));
 ?>
 ```

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ the related HTTP method:
 
 - `$router->addGet()`
 - `$router->addDelete()`
-- `$router->addOption()`
+- `$router->addOptions()`
 - `$router->addPatch()`
 - `$router->addPost()`
 - `$router->addPut()`
@@ -216,6 +216,18 @@ You can extend a route specification with the following methods:
     Note that `setServer()` is also available, but this will replace any
     previous expressions entirely, instead of merging with the existing
     expressions.
+
+- `addAccept()` -- Adds a list of content types that the route responds to. Note that this is *not* content negotiation per se, only a "sanity check" to make sure the route can eventually provide the content types specified by the request.
+
+        addAccept(array(
+            'application/json',
+            'application/xml',
+            'text/csv',
+        ));
+
+    Note that `setAccept()` is also available, but this will replace any
+    previous content types entirely, instead of merging with the existing
+    types.
 
 - `addValues()` -- Adds default values for the params.
 

--- a/src/AbstractSpec.php
+++ b/src/AbstractSpec.php
@@ -21,6 +21,7 @@ class AbstractSpec
 {
 	protected $tokens      = array();
 	protected $server      = array();
+    protected $accept      = array();
 	protected $values      = array();
 	protected $secure      = null;
 	protected $wildcard    = null;
@@ -89,6 +90,16 @@ class AbstractSpec
         $this->server = array_merge($this->server, $server);
         $this->regex = null;
         return $this;
+    }
+
+    public function setAccept(array $accept)
+    {
+        $this->accept = $accept;
+    }
+
+    public function addAccept(array $accept)
+    {
+        $this->accept = array_merge($this->accept, $accept);
     }
 
     /**

--- a/src/AbstractSpec.php
+++ b/src/AbstractSpec.php
@@ -19,16 +19,16 @@ namespace Aura\Router;
  */
 class AbstractSpec
 {
-	protected $tokens      = array();
-	protected $server      = array();
+    protected $tokens      = array();
+    protected $server      = array();
     protected $accept      = array();
-	protected $values      = array();
-	protected $secure      = null;
-	protected $wildcard    = null;
-	protected $routable    = true;
-	protected $is_match    = null;
-	protected $generate    = null;
-	protected $regex       = null;
+    protected $values      = array();
+    protected $secure      = null;
+    protected $wildcard    = null;
+    protected $routable    = true;
+    protected $is_match    = null;
+    protected $generate    = null;
+    protected $regex       = null;
 
     /**
      *

--- a/src/AbstractSpec.php
+++ b/src/AbstractSpec.php
@@ -21,6 +21,7 @@ class AbstractSpec
 {
     protected $tokens      = array();
     protected $server      = array();
+    protected $method      = array();
     protected $accept      = array();
     protected $values      = array();
     protected $secure      = null;
@@ -88,18 +89,27 @@ class AbstractSpec
     public function addServer(array $server)
     {
         $this->server = array_merge($this->server, $server);
-        $this->regex = null;
         return $this;
     }
 
-    public function setAccept(array $accept)
+    public function setMethod($method)
     {
-        $this->accept = $accept;
+        $this->method = (array) $method;
     }
 
-    public function addAccept(array $accept)
+    public function addMethod($method)
     {
-        $this->accept = array_merge($this->accept, $accept);
+        $this->method = array_merge($this->method, (array) $method);
+    }
+
+    public function setAccept($accept)
+    {
+        $this->accept = (array) $accept;
+    }
+
+    public function addAccept($accept)
+    {
+        $this->accept = array_merge($this->accept, (array) $accept);
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -103,6 +103,8 @@ class Route extends AbstractSpec
 
     protected $score = 0;
 
+    protected $failure = null;
+
     /**
      *
      * Constructor.
@@ -165,6 +167,7 @@ class Route extends AbstractSpec
         $this->debug = array();
         $this->params = array();
         $this->score = 0;
+        $this->failure = null;
         if ($this->isFullMatch($path, $server)) {
             $this->setParams();
             return true;

--- a/src/Route.php
+++ b/src/Route.php
@@ -294,6 +294,7 @@ class Route extends AbstractSpec
             && $this->isRegexMatch($path)
             && $this->isServerMatch($server)
             && $this->isSecureMatch($server)
+            && $this->isMethodMatch($server)
             && $this->isAcceptMatch($server)
             && $this->isCustomMatch($server);
     }
@@ -307,6 +308,7 @@ class Route extends AbstractSpec
         $this->debug[] = 'Not routable.';
         return false;
     }
+
     /**
      *
      * Checks that the path matches the Route regex.
@@ -391,11 +393,7 @@ class Route extends AbstractSpec
 
     protected function isAcceptMatch($server)
     {
-        if (! $this->accept) {
-            return true;
-        }
-
-        if (! isset($server['HTTP_ACCEPT'])) {
+        if (! $this->accept || ! isset($server['HTTP_ACCEPT'])) {
             return true;
         }
 
@@ -425,6 +423,15 @@ class Route extends AbstractSpec
             return false;
         }
         return isset($matches[3]) && $matches[3] !== '0.0';
+    }
+
+    protected function isMethodMatch($server)
+    {
+        if (! $this->method) {
+            return true;
+        }
+
+        return in_array($server['REQUEST_METHOD'], $this->method);
     }
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -291,11 +291,11 @@ class Route extends AbstractSpec
     protected function isFullMatch($path, array $server)
     {
         return $this->isRoutableMatch()
-            && $this->isRegexMatch($path)
-            && $this->isServerMatch($server)
             && $this->isSecureMatch($server)
+            && $this->isRegexMatch($path)
             && $this->isMethodMatch($server)
             && $this->isAcceptMatch($server)
+            && $this->isServerMatch($server)
             && $this->isCustomMatch($server);
     }
 

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -203,7 +203,7 @@ class RouteCollection extends AbstractSpec implements
     public function addGet($name, $path)
     {
         $route = $this->add($name, $path);
-        $route->addServer(array('REQUEST_METHOD' => 'GET'));
+        $route->addMethod('GET');
         return $route;
     }
 
@@ -221,7 +221,7 @@ class RouteCollection extends AbstractSpec implements
     public function addDelete($name, $path)
     {
         $route = $this->add($name, $path);
-        $route->addServer(array('REQUEST_METHOD' => 'DELETE'));
+        $route->addMethod('DELETE');
         return $route;
     }
 
@@ -239,7 +239,7 @@ class RouteCollection extends AbstractSpec implements
     public function addOptions($name, $path)
     {
         $route = $this->add($name, $path);
-        $route->addServer(array('REQUEST_METHOD' => 'OPTIONS'));
+        $route->addMethod('OPTIONS');
         return $route;
     }
 
@@ -257,7 +257,7 @@ class RouteCollection extends AbstractSpec implements
     public function addPatch($name, $path)
     {
         $route = $this->add($name, $path);
-        $route->addServer(array('REQUEST_METHOD' => 'PATCH'));
+        $route->addMethod('PATCH');
         return $route;
     }
 
@@ -275,7 +275,7 @@ class RouteCollection extends AbstractSpec implements
     public function addPost($name, $path)
     {
         $route = $this->add($name, $path);
-        $route->addServer(array('REQUEST_METHOD' => 'POST'));
+        $route->addMethod('POST');
         return $route;
     }
 
@@ -293,7 +293,7 @@ class RouteCollection extends AbstractSpec implements
     public function addPut($name, $path)
     {
         $route = $this->add($name, $path);
-        $route->addServer(array('REQUEST_METHOD' => 'PUT'));
+        $route->addMethod('PUT');
         return $route;
     }
 
@@ -374,6 +374,7 @@ class RouteCollection extends AbstractSpec implements
         $vars = array(
             'tokens',
             'server',
+            'method',
             'accept',
             'values',
             'secure',

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -374,6 +374,7 @@ class RouteCollection extends AbstractSpec implements
         $vars = array(
             'tokens',
             'server',
+            'accept',
             'values',
             'secure',
             'wildcard',

--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -45,115 +45,115 @@ class RouteCollection extends AbstractSpec implements
      */
     protected $route_factory;
 
-	protected $name_prefix = null;
-	protected $path_prefix = null;
-	protected $resource_callable = null;
-	protected $route_callable = null;
+    protected $name_prefix = null;
+    protected $path_prefix = null;
+    protected $resource_callable = null;
+    protected $route_callable = null;
 
-	/**
-	 *
-	 * Constructor.
-	 *
-	 * @param RouteFactory $route_factory A factory to create route objects.
-	 *
-	 * @param array $routes An array of route objects.
-	 *
-	 */
-	public function __construct(
-	    RouteFactory $route_factory,
-	    array $routes = array()
-	) {
-	    $this->route_factory = $route_factory;
+    /**
+     *
+     * Constructor.
+     *
+     * @param RouteFactory $route_factory A factory to create route objects.
+     *
+     * @param array $routes An array of route objects.
+     *
+     */
+    public function __construct(
+        RouteFactory $route_factory,
+        array $routes = array()
+    ) {
+        $this->route_factory = $route_factory;
         $this->routes = $routes;
         $this->setResourceCallable(array($this, 'resourceCallable'));
         $this->setRouteCallable(array($this, 'routeCallable'));
-	}
+    }
 
-	/**
-	 *
-	 * ArrayAccess: gets a route by name.
-	 *
-	 * @param string $name The route name.
-	 *
-	 * @return Route
-	 *
-	 */
-	public function offsetGet($name)
-	{
+    /**
+     *
+     * ArrayAccess: gets a route by name.
+     *
+     * @param string $name The route name.
+     *
+     * @return Route
+     *
+     */
+    public function offsetGet($name)
+    {
         return $this->routes[$name];
-	}
+    }
 
-	/**
-	 *
-	 * ArrayAccess: sets a route by name.
-	 *
-	 * @param string $name The route name.
-	 *
-	 * @param Route $route The route object.
-	 *
-	 * @return null
-	 *
-	 */
-	public function offsetSet($name, $route)
-	{
-	    if (! $route instanceof Route) {
-	        throw new Exception\UnexpectedValue;
-	    }
+    /**
+     *
+     * ArrayAccess: sets a route by name.
+     *
+     * @param string $name The route name.
+     *
+     * @param Route $route The route object.
+     *
+     * @return null
+     *
+     */
+    public function offsetSet($name, $route)
+    {
+        if (! $route instanceof Route) {
+            throw new Exception\UnexpectedValue;
+        }
 
-	    $this->routes[$name] = $route;
-	}
+        $this->routes[$name] = $route;
+    }
 
-	/**
-	 *
-	 * ArrayAccess: does a route name exist?
-	 *
-	 * @param string $name The route name.
-	 *
-	 * @return bool
-	 *
-	 */
-	public function offsetExists($name)
-	{
-	    return isset($this->routes[$name]);
-	}
+    /**
+     *
+     * ArrayAccess: does a route name exist?
+     *
+     * @param string $name The route name.
+     *
+     * @return bool
+     *
+     */
+    public function offsetExists($name)
+    {
+        return isset($this->routes[$name]);
+    }
 
-	/**
-	 *
-	 * ArrayAccess: removes a route by name.
-	 *
-	 * @param string $name The route name to remove.
-	 *
-	 * @return null
-	 *
-	 */
-	public function offsetUnset($name)
-	{
-	    unset($this->routes[$name]);
-	}
+    /**
+     *
+     * ArrayAccess: removes a route by name.
+     *
+     * @param string $name The route name to remove.
+     *
+     * @return null
+     *
+     */
+    public function offsetUnset($name)
+    {
+        unset($this->routes[$name]);
+    }
 
-	/**
-	 *
-	 * Countable: returns the number of routes in the collection.
-	 *
-	 * @return int
-	 *
-	 */
-	public function count()
-	{
-	    return count($this->routes);
-	}
+    /**
+     *
+     * Countable: returns the number of routes in the collection.
+     *
+     * @return int
+     *
+     */
+    public function count()
+    {
+        return count($this->routes);
+    }
 
-	/**
-	 *
-	 * IteratorAggregate: returns the iterator object.
-	 *
-	 * @return ArrayIterator
-	 *
-	 */
-	public function getIterator()
-	{
-	    return new ArrayIterator($this->routes);
-	}
+    /**
+     *
+     * IteratorAggregate: returns the iterator object.
+     *
+     * @return ArrayIterator
+     *
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->routes);
+    }
 
     /**
      *

--- a/src/RouteFactory.php
+++ b/src/RouteFactory.php
@@ -42,17 +42,17 @@ class RouteFactory
         'path_prefix' => null,
     );
 
-	/**
-	 *
-	 * Constructor.
-	 *
-	 * @param string $class The route class to create.
-	 *
-	 */
-	public function __construct($class = 'Aura\Router\Route')
-	{
-	    $this->class = $class;
-	}
+    /**
+     *
+     * Constructor.
+     *
+     * @param string $class The route class to create.
+     *
+     */
+    public function __construct($class = 'Aura\Router\Route')
+    {
+        $this->class = $class;
+    }
 
     /**
      *

--- a/src/RouteFactory.php
+++ b/src/RouteFactory.php
@@ -32,6 +32,8 @@ class RouteFactory
     protected $spec = array(
         'tokens' => array(),
         'server' => array(),
+        'method' => array(),
+        'accept' => array(),
         'values' => array(),
         'secure' => null,
         'wildcard' => null,
@@ -81,6 +83,8 @@ class RouteFactory
         $route = new $class($path, $name);
         $route->addTokens($spec['tokens']);
         $route->addServer($spec['server']);
+        $route->addMethod($spec['method']);
+        $route->addAccept($spec['accept']);
         $route->addValues($spec['values']);
         $route->setSecure($spec['secure']);
         $route->setWildcard($spec['wildcard']);

--- a/src/Router.php
+++ b/src/Router.php
@@ -50,12 +50,12 @@ class Router
 
     protected $generator;
 
-	/**
-	 *
-	 * Constructor.
-	 *
-	 * @param RouteCollection $routes A route collection object.
-	 */
+    /**
+     *
+     * Constructor.
+     *
+     * @param RouteCollection $routes A route collection object.
+     */
     public function __construct(RouteCollection $routes, Generator $generator)
     {
         $this->routes = $routes;

--- a/src/Router.php
+++ b/src/Router.php
@@ -50,6 +50,8 @@ class Router
 
     protected $generator;
 
+    protected $closest_match;
+
     /**
      *
      * Constructor.
@@ -93,18 +95,32 @@ class Router
     public function match($path, array $server = array())
     {
         $this->debug = array();
+        $this->closest_match = null;
 
         foreach ($this->routes as $route) {
-            $match = $route->isMatch($path, $server);
+
             $this->debug[] = $route;
+
+            $match = $route->isMatch($path, $server);
             if ($match) {
                 $this->matched_route = $route;
                 return $route;
+            }
+
+            $closer_match = ! $this->closest_match
+                         || $route->score > $this->closest_match->score;
+            if ($closer_match) {
+                $this->closest_match = $route;
             }
         }
 
         $this->matched_route = false;
         return false;
+    }
+
+    public function getClosestMatch()
+    {
+        return $this->closest_match;
     }
 
     /**

--- a/tests/src/RouteTest.php
+++ b/tests/src/RouteTest.php
@@ -487,4 +487,65 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $actual = $route->isMatch('/foo/bar/baz', $this->server);
         $this->assertTrue($actual);
     }
+
+    public function testIsAcceptMatch()
+    {
+        $proto = $this->factory->newInstance('/foo/bar/baz');
+
+        // match when no HTTP_ACCEPT
+        $route = clone $proto;
+        $route->addAccept(array('zim/gir'));
+        $server = array();
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertTrue($actual);
+
+        // match */*
+        $route = clone $proto;
+        $route->addAccept(array('zim/gir'));
+        $server = array('HTTP_ACCEPT' => 'text/*;q=0.9,application/json,*/*;q=0.1,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertTrue($actual);
+
+        // do not match */* when q=0.0
+        $route = clone $proto;
+        $route->setAccept(array('zim/gir'));
+        $server = array('HTTP_ACCEPT' => 'text/*;q=0.9,application/json,*/*;q=0.0,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertFalse($actual);
+
+        // match text/csv
+        $route = clone $proto;
+        $route->setAccept(array('text/csv'));
+        $server = array('HTTP_ACCEPT' => 'text/csv;q=0.9,application/json,*/*;q=0.0,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertTrue($actual);
+
+        // do not match text/csv when q=0
+        $route = clone $proto;
+        $route->setAccept(array('text/csv'));
+        $server = array('HTTP_ACCEPT' => 'application/json,text/csv;q=0.0,*/*;q=0.0,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertFalse($actual);
+
+        // match text/*
+        $route = clone $proto;
+        $route->setAccept(array('text/csv'));
+        $server = array('HTTP_ACCEPT' => 'application/json,text/*;q=0.9,*/*;q=0.1,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertTrue($actual);
+
+        // do not match text/* when q=0
+        $route = clone $proto;
+        $route->setAccept(array('text/csv'));
+        $server = array('HTTP_ACCEPT' => 'application/json,text/*;q=0.0,*/*;q=0.1,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertTrue($actual);
+
+        // match application/json without q score
+        $route = clone $proto;
+        $route->setAccept(array('application/json'));
+        $server = array('HTTP_ACCEPT' => 'application/json,text/*;q=0.0,*/*;q=0.1,application/xml');
+        $actual = $route->isMatch('/foo/bar/baz', $server);
+        $this->assertTrue($actual);
+    }
 }

--- a/tests/src/RouterTest.php
+++ b/tests/src/RouterTest.php
@@ -36,7 +36,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $this->router->attach('during', '/during', function ($router) {
             $router->setTokens(array('id' => '\d+'));
-            $router->setServer(array('HTTP_REQUEST' => 'GET'));
+            $router->setMethod('GET');
             $router->setValues(array('zim' => 'gir'));
             $router->setSecure(true);
             $router->setWildcard('other');
@@ -53,6 +53,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $expect = array(
             'tokens' => array(),
             'server' => array(),
+            'method' => array(),
             'values' => array('action' => 'before'),
             'secure' => null,
             'wildcard' => null,
@@ -68,7 +69,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $actual = $routes['during.bar'];
         $expect = array(
             'tokens' => array('id' => '\d+'),
-            'server' => array('HTTP_REQUEST' => 'GET'),
+            'method' => array('GET'),
             'values' => array('zim' => 'gir', 'action' => 'during.bar'),
             'secure' => true,
             'wildcard' => 'other',
@@ -137,7 +138,6 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $expect_values = array(
             'action' => 'resource.read',
             'id' => '42',
-            'REQUEST_METHOD' => 'GET',
         );
         $this->assertEquals($expect_values, $actual->params);
 
@@ -150,7 +150,6 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $expect_values = array(
             'action' => 'resource.edit',
             'id' => '42',
-            'REQUEST_METHOD' => 'POST',
         );
         $this->assertEquals($expect_values, $actual->params);
 
@@ -171,7 +170,6 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $expect_values = array(
             'action' => 'resource.delete',
             'id' => '42',
-            'REQUEST_METHOD' => 'DELETE',
         );
         $this->assertEquals($expect_values, $actual->params);
 
@@ -184,7 +182,6 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $expect_values = array(
             'action' => 'resource.patch',
             'id' => '42',
-            'REQUEST_METHOD' => 'PATCH',
         );
         $this->assertEquals($expect_values, $actual->params);
 
@@ -197,7 +194,6 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $expect_values = array(
             'action' => 'resource.options',
             'id' => '42',
-            'REQUEST_METHOD' => 'OPTIONS',
         );
         $this->assertEquals($expect_values, $actual->params);
 
@@ -280,9 +276,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'GET',
-            ),
+            'method' => array('GET'),
             'values' => array(
                 'action' => 'blog.browse',
             ),
@@ -296,9 +290,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'GET',
-            ),
+            'method' => array('GET'),
             'values' => array(
                 'action' => 'blog.read',
             ),
@@ -312,9 +304,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'GET',
-            ),
+            'method' => array('GET'),
             'values' => array(
                 'action' => 'blog.add',
             ),
@@ -328,9 +318,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'GET',
-            ),
+            'method' => array('GET'),
             'values' => array(
                 'action' => 'blog.edit',
             ),
@@ -344,9 +332,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'DELETE',
-            ),
+            'method' => array('DELETE'),
             'values' => array(
                 'action' => 'blog.delete',
             ),
@@ -360,9 +346,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'POST',
-            ),
+            'method' => array('POST'),
             'values' => array(
                 'action' => 'blog.create',
             ),
@@ -376,9 +360,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'PATCH',
-            ),
+            'method' => array('PATCH'),
             'values' => array(
                 'action' => 'blog.update',
             ),
@@ -392,9 +374,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
                 'id' => '\d+',
                 'format' => '(\.[^/]+)?',
             ),
-            'server' => array(
-                'REQUEST_METHOD' => 'PUT',
-            ),
+            'method' => array('PUT'),
             'values' => array(
                 'action' => 'blog.replace',
             ),


### PR DESCRIPTION
- add setAccept() and addAccept() route conditions, along with appropriate matching logic
- create separate setMethod() and addMethod() logic for matching HTTP methods (instead of embedding in generic $_SERVER conditions)
- track a "score" on each route that says how well it matched, via new pass() and fail() methods
- the Router now retains the closest (highest-scoring) route that didn't actually match
- there are no intentional BC breaks, but let me know if you find any
