### PR TITLE
Support HTTP_X_FORWARDED_PROTO header

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -382,7 +382,9 @@ class Route extends AbstractSpec
     protected function serverIsSecure($server)
     {
         return (isset($server['HTTPS']) && $server['HTTPS'] == 'on')
-            || (isset($server['SERVER_PORT']) && $server['SERVER_PORT'] == 443);
+            || (isset($server['SERVER_PORT']) && $server['SERVER_PORT'] == 443)
+            || (isset($server['HTTP_X_FORWARDED_PROTO']) && strtolower($server['HTTP_X_FORWARDED_PROTO']) === 'https')
+            ;
     }
 
     /**


### PR DESCRIPTION
If the website is behind the proxy, HTTP_X_FORWARDED_PROTO shows the real protocol used accessing the proxy.
