### PR TITLE
add basepath support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 php:
   - 5.3

--- a/src/Regex.php
+++ b/src/Regex.php
@@ -55,10 +55,10 @@ class Regex
      * @return bool
      *
      */
-    public function match(Route $route, $path)
+    public function match(Route $route, $path, $basepath = null)
     {
         $this->route = $route;
-        $this->regex = $this->route->path;
+        $this->regex = $basepath . $this->route->path;
         $this->setRegexOptionalParams();
         $this->setRegexParams();
         $this->setRegexWildcard();

--- a/src/Route.php
+++ b/src/Route.php
@@ -241,13 +241,13 @@ class Route extends AbstractSpec
      * @return bool
      *
      */
-    public function isMatch($path, array $server)
+    public function isMatch($path, array $server, $basepath = null)
     {
         $this->debug = array();
         $this->params = array();
         $this->score = 0;
         $this->failed = null;
-        if ($this->isFullMatch($path, $server)) {
+        if ($this->isFullMatch($path, $server, $basepath)) {
             $this->setParams();
             return true;
         }
@@ -266,11 +266,11 @@ class Route extends AbstractSpec
      * @return bool
      *
      */
-    protected function isFullMatch($path, array $server)
+    protected function isFullMatch($path, array $server, $basepath = null)
     {
         return $this->isRoutableMatch()
             && $this->isSecureMatch($server)
-            && $this->isRegexMatch($path)
+            && $this->isRegexMatch($path, $basepath)
             && $this->isMethodMatch($server)
             && $this->isAcceptMatch($server)
             && $this->isServerMatch($server)
@@ -394,10 +394,10 @@ class Route extends AbstractSpec
      * @return bool True on a match, false if not.
      *
      */
-    protected function isRegexMatch($path)
+    protected function isRegexMatch($path, $basepath = null)
     {
         $regex = clone $this->regex;
-        $match = $regex->match($this, $path);
+        $match = $regex->match($this, $path, $basepath);
         if (! $match) {
             return $this->fail(self::FAILED_REGEX);
         }

--- a/src/Router.php
+++ b/src/Router.php
@@ -72,6 +72,8 @@ class Router
      */
     protected $failed_route = null;
 
+    protected $basepath;
+
     /**
      *
      * Constructor.
@@ -81,10 +83,14 @@ class Router
      * @param Generator $generator A URL path generator.
      *
      */
-    public function __construct(RouteCollection $routes, Generator $generator)
-    {
+    public function __construct(
+        RouteCollection $routes,
+        Generator $generator,
+        $basepath = null
+    ) {
         $this->routes = $routes;
         $this->generator = $generator;
+        $this->basepath = $basepath;
     }
 
     /**
@@ -124,7 +130,7 @@ class Router
 
             $this->debug[] = $route;
 
-            $match = $route->isMatch($path, $server);
+            $match = $route->isMatch($path, $server, $this->basepath);
             if ($match) {
                 $this->matched_route = $route;
                 return $route;
@@ -187,7 +193,7 @@ class Router
     public function generate($name, $data = array())
     {
         $route = $this->getRouteForGenerate($name);
-        return $this->generator->generate($route, $data);
+        return $this->basepath . $this->generator->generate($route, $data);
     }
 
     /**
@@ -208,7 +214,7 @@ class Router
     public function generateRaw($name, $data = array())
     {
         $route = $this->getRouteForGenerate($name);
-        return $this->generator->generateRaw($route, $data);
+        return $this->basepath . $this->generator->generateRaw($route, $data);
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -90,7 +90,7 @@ class Router
     ) {
         $this->routes = $routes;
         $this->generator = $generator;
-        $this->basepath = $basepath;
+        $this->basepath = rtrim($basepath, '/');
     }
 
     /**

--- a/src/RouterFactory.php
+++ b/src/RouterFactory.php
@@ -24,11 +24,12 @@ class RouterFactory
      * @return Router
      *
      */
-    public function newInstance()
+    public function newInstance($basepath = null)
     {
         return new Router(
             new RouteCollection(new RouteFactory),
-            new Generator
+            new Generator,
+            $basepath
         );
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -8,13 +8,13 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->factory = new RouterFactory;
         $this->router = $this->newRouter();
     }
 
-    protected function newRouter()
+    protected function newRouter($basepath = null)
     {
-        return $this->factory->newInstance();
+        $factory = new RouterFactory;
+        return $factory->newInstance($basepath);
     }
 
     protected function assertIsRoute($actual)
@@ -497,5 +497,23 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->router->add('foo.bar', '/foo/bar', 'DirectAction');
         $actual = $this->router->match('/foo/bar');
         $this->assertSame('DirectAction', $actual->values['action']);
+    }
+
+    public function testWithBasepath()
+    {
+        $this->router = $this->newRouter('/path/to/sub/index.php');
+        $this->router->add('foo.bar', '/foo/bar', 'DirectAction');
+
+        // should fail without basepath
+        $this->assertFalse($this->router->match('/foo/bar'));
+
+        // should pass with basepath
+        $actual = $this->router->match('/path/to/sub/index.php/foo/bar');
+        $this->assertSame('DirectAction', $actual->values['action']);
+
+        // should get the basepath in place
+        $expect = '/path/to/sub/index.php/foo/bar';
+        $actual = $this->router->generate('foo.bar');
+        $this->assertSame($expect, $actual);
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -499,7 +499,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('DirectAction', $actual->values['action']);
     }
 
-    public function testWithBasepath()
+    public function testWithBasepathIndex()
     {
         $this->router = $this->newRouter('/path/to/sub/index.php');
         $this->router->add('foo.bar', '/foo/bar', 'DirectAction');
@@ -513,6 +513,25 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         // should get the basepath in place
         $expect = '/path/to/sub/index.php/foo/bar';
+        $actual = $this->router->generate('foo.bar');
+        $this->assertSame($expect, $actual);
+    }
+
+
+    public function testWithBasepathDir()
+    {
+        $this->router = $this->newRouter('/path/to/sub');
+        $this->router->add('foo.bar', '/foo/bar', 'DirectAction');
+
+        // should fail without basepath
+        $this->assertFalse($this->router->match('/foo/bar'));
+
+        // should pass with basepath
+        $actual = $this->router->match('/path/to/sub/foo/bar');
+        $this->assertSame('DirectAction', $actual->values['action']);
+
+        // should get the basepath in place
+        $expect = '/path/to/sub/foo/bar';
         $actual = $this->router->generate('foo.bar');
         $this->assertSame($expect, $actual);
     }


### PR DESCRIPTION
This should be a fix for #86 -- @harikt @pine3ree please review and comment.

Basically, you create a RouterFactory with the basepath you want; that would be the subdirectory in which the application lives. You can then add routes as normal, without having to specify the basepath prefix; the matcher will match properly, and the generator will generate paths with the basepath prefix in place.
