### PR TITLE
Change default factories to use serializable method calls

### DIFF
--- a/src/RouterContainer.php
+++ b/src/RouterContainer.php
@@ -121,22 +121,63 @@ class RouterContainer
     {
         $this->basepath = $basepath;
 
-        $this->setLoggerFactory(function () {
-            return new NullLogger();
-        });
+        $this->setLoggerFactory([$this, 'loggerFactory']);
 
-        $this->setRouteFactory(function () {
-            return new Route();
-        });
+        $this->setRouteFactory([$this, 'routeFactory']);
 
-        $self = $this;
-        $this->setMapFactory(function () use ($self) {
-            return new Map($self->getRoute());
-        });
+        $this->setMapFactory([$this, 'mapFactory']);
 
-        $this->setMapBuilder(function (Map $map) {
-            // do nothing
-        });
+        $this->setMapBuilder([$this, 'buildMap']);
+    }
+
+    /**
+     * Creates a Logger
+     *
+     * @return NullLogger
+     *
+     * @access protected
+     */
+    protected function loggerFactory()
+    {
+        return new NullLogger();
+    }
+
+    /**
+     * Creates a new Route
+     *
+     * @return Route
+     *
+     * @access protected
+     */
+    protected function routeFactory()
+    {
+        return new Route();
+    }
+
+    /**
+     * mapFactory
+     *
+     * @return mixed
+     *
+     * @access protected
+     */
+    protected function mapFactory()
+    {
+        return new Map($this->getRoute());
+    }
+
+    /**
+     * Builds a map
+     *
+     * @param Map $map DESCRIPTION
+     *
+     * @return mixed
+     *
+     * @access protected
+     */
+    protected function buildMap(Map $map)
+    {
+        // do nothing
     }
 
     /**


### PR DESCRIPTION
> Add methods for default factories, and set factories to array callbacks

Radar has a "cached container" functionality which [serializes the DI
container](https://github.com/radarphp/Radar.Adr/blob/1.x/src/Boot.php#L34).

If one [extracts setup to configuration](https://github.com/radarphp/Radar.Project/blob/1.x/docs/container.md#extracting-setup-to-configuration),
then you create and instance of `Aura\Router\RouterContainer` in the DI
container.

Currently the default factories and the "map builder" are set by the constructor
as anonymous functions. This precludes serialization.

> Serialization of 'Closure' is not allowed

Does future PHP plan to support serialization of closures?
