### PR TITLE
PHPDoc fixes

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -393,6 +393,8 @@ class Route
      * @param string $name The route name.
      *
      * @return $this
+     * 
+     * @throws Exception\ImmutableProperty when the name has already been set.
      *
      */
     public function name($name)
@@ -433,6 +435,8 @@ class Route
      * @param string $path The route path.
      *
      * @return $this
+     *
+     * @throws Exception\ImmutableProperty when the name has already been set.
      *
      */
     public function path($path)


### PR DESCRIPTION
Add missing @throws for exceptions to hush up complaints from PHPDoc-aware tools, like PhpStorm.  ;-)
