### PR TITLE
Identify requests with the X-Forwarded-Proto header set to https as secure

### DIFF
--- a/docs/defining-routes.md
+++ b/docs/defining-routes.md
@@ -141,7 +141,7 @@ $map->post('blog.edit', '/blog/{id}')
 
 ## Secure Protocols
 
-You can use the `secure()` method to specify that a route should only match a secure protcol. (Specifically, `$_SERVER['HTTPS']` must be on, or the request must be on port 443.)
+You can use the `secure()` method to specify that a route should only match a secure protcol. (Specifically, `$_SERVER['HTTPS']` must be on, or the request must be on port 443, or `$_SERVER['HTTP_X_FORWARDED_PROTO']` must equal `https`)
 
 ```php
 <?php

--- a/src/Rule/Secure.php
+++ b/src/Rule/Secure.php
@@ -38,7 +38,7 @@ class Secure implements RuleInterface
         }
 
         $server = $request->getServerParams();
-        $secure = $this->https($server) || $this->port443($server);
+        $secure = $this->https($server) || $this->port443($server) || $this->forwarded($server);
         return $route->secure == $secure;
     }
 
@@ -71,5 +71,20 @@ class Secure implements RuleInterface
     {
         return isset($server['SERVER_PORT'])
             && $server['SERVER_PORT'] == 443;
+    }
+
+    /**
+     *
+     * Is X-Forwarded-Proto https?
+     *
+     * @param array $server The server params.
+     *
+     * @return bool
+     *
+     */
+    protected function forwarded($server)
+    {
+        return isset($server['HTTP_X_FORWARDED_PROTO'])
+            && $server['HTTP_X_FORWARDED_PROTO'] == 'https';
     }
 }

--- a/tests/Rule/SecureTest.php
+++ b/tests/Rule/SecureTest.php
@@ -78,4 +78,40 @@ class SecureTest extends AbstractRuleTest
         $request = $this->newRequest('/foo/bar/baz', ['SERVER_PORT' => '443']);
         $this->assertIsNotMatch($request, $route);
     }
+
+
+    public function testIsSecureMatch_forwarded()
+    {
+        /**
+         * secure required
+         */
+        $proto = $this->newRoute('/foo/bar/baz')
+            ->secure(true);
+
+        // correct
+        $route = clone $proto;
+        $request = $this->newRequest('/foo/bar/baz', ['HTTP_X_FORWARDED_PROTO' => 'https']);
+        $this->assertIsMatch($request, $route);
+
+        // not secure
+        $route = clone $proto;
+        $request = $this->newRequest('/foo/bar/baz', ['HTTP_X_FORWARDED_PROTO' => 'http']);
+        $this->assertIsNotMatch($request, $route);
+
+        /**
+         * not-secure required
+         */
+        $proto = $this->newRoute('/foo/bar/baz')
+            ->secure(false);
+
+        // correct
+        $route = clone $proto;
+        $request = $this->newRequest('/foo/bar/baz', ['HTTP_X_FORWARDED_PROTO' => 'http']);
+        $this->assertIsMatch($request, $route);
+
+        // secured when it should not be
+        $route = clone $proto;
+        $request = $this->newRequest('/foo/bar/baz', ['HTTP_X_FORWARDED_PROTO' => 'https']);
+        $this->assertIsNotMatch($request, $route);
+    }
 }


### PR DESCRIPTION
When a secure request is terminated at a load balancer and then forwarded to a server, it should
set the X-Forwarded-Proto header indicating that the original request used the https protocol.
Previously, the Secure Rule had two means of determining a request was secure $_SERVER['HTTPS'] == 'on' and port = 443. This adds a check for $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'.
