### PR TITLE
Update signatures for generate and generateRaw

### DIFF
--- a/docs/other-topics.md
+++ b/docs/other-topics.md
@@ -58,7 +58,7 @@ $route = $matcher->match($request);
 
 // generating a path from the route will add the base path automatically
 $generator = $routerContainer->getGenerator();
-$path = $generator->generate('blog.read', '88');
+$path = $generator->generate('blog.read', ['id' => 88]);
 echo $path; // "/path/to/subdir/blog/88"
 ?>
 ```

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -111,7 +111,7 @@ class Generator
      * @throws Exception\RouteNotFound
      *
      */
-    public function generate($name, $data = [])
+    public function generate($name, array $data = [])
     {
         return $this->build($name, $data, false);
     }
@@ -131,7 +131,7 @@ class Generator
      * @throws Exception\RouteNotFound
      *
      */
-    public function generateRaw($name, $data = [])
+    public function generateRaw($name, array $data = [])
     {
         return $this->build($name, $data, true);
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -150,7 +150,7 @@ class Generator
      * @return string
      *
      */
-    protected function build($name, $data, $raw)
+    protected function build($name, array $data, $raw)
     {
         $this->raw = $raw;
         $this->route = $this->map->getRoute($name);

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -194,9 +194,18 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGenerateErrorsWithoutDataArray()
     {
-        $this->expectException(\PHPUnit_Framework_Exception::class);
-        $this->expectExceptionMessage('Argument 2 passed to Aura\\Router\\Generator::generate() must be of the type array, string given');
-        $this->generator->generate('test', 'nope');
+        try {
+            $this->generator->generate('test', 'nope');
+        }
+        catch(\PHPUnit_Framework_Exception $e) {
+            $this->assertStringStartsWith(
+                'Argument 2 passed to Aura\\Router\\Generator::generate() must be of the type array, string given',
+                $e->getMessage()
+            );
+            return;
+        }
+
+        $this->fail("Exception was not thrown");
     }
 
     /**
@@ -204,8 +213,17 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testGenerateRawErrorsWhenPassedNonArray()
     {
-        $this->expectException(\PHPUnit_Framework_Exception::class);
-        $this->expectExceptionMessage('Argument 2 passed to Aura\\Router\\Generator::generateRaw() must be of the type array, string given');
-        $this->generator->generateRaw('test', 'nope');
+        try {
+            $this->generator->generateRaw('test', 'nope');
+        }
+        catch(\PHPUnit_Framework_Exception $e) {
+            $this->assertStringStartsWith(
+                'Argument 2 passed to Aura\\Router\\Generator::generateRaw() must be of the type array, string given',
+                $e->getMessage()
+            );
+            return;
+        }
+
+        $this->fail("Exception was not thrown");
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -3,7 +3,14 @@ namespace Aura\Router;
 
 class GeneratorTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Map
+     */
     protected $map;
+
+    /**
+     * @var Generator
+     */
     protected $generator;
 
     protected function setUp()
@@ -135,7 +142,6 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
             'package' => 'package+name',
             'file' => 'foo/bar/baz.jpg',
         ];
-        $raw = ['file'];
         $actual = $this->generator->generateRaw('test', $data);
         $expect = '/vendor+name/package+name/foo/bar/baz.jpg';
         $this->assertSame($actual, $expect);
@@ -181,5 +187,25 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
 
         $url = $this->generator->generate('test', ['id' => 42, 'host' => 'bar']);
         $this->assertEquals('https://bar.example.com/blog/42/edit', $url);
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testGenerateErrorsWithoutDataArray()
+    {
+        $this->expectException(\PHPUnit_Framework_Exception::class);
+        $this->expectExceptionMessage('Argument 2 passed to Aura\\Router\\Generator::generate() must be of the type array, string given');
+        $this->generator->generate('test', 'nope');
+    }
+
+    /**
+     * @coversNothing
+     */
+    public function testGenerateRawErrorsWhenPassedNonArray()
+    {
+        $this->expectException(\PHPUnit_Framework_Exception::class);
+        $this->expectExceptionMessage('Argument 2 passed to Aura\\Router\\Generator::generateRaw() must be of the type array, string given');
+        $this->generator->generateRaw('test', 'nope');
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -188,42 +188,4 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $url = $this->generator->generate('test', ['id' => 42, 'host' => 'bar']);
         $this->assertEquals('https://bar.example.com/blog/42/edit', $url);
     }
-
-    /**
-     * @coversNothing
-     */
-    public function testGenerateErrorsWithoutDataArray()
-    {
-        try {
-            $this->generator->generate('test', 'nope');
-        }
-        catch(\PHPUnit_Framework_Exception $e) {
-            $this->assertStringStartsWith(
-                'Argument 2 passed to Aura\\Router\\Generator::generate() must be of the type array, string given',
-                $e->getMessage()
-            );
-            return;
-        }
-
-        $this->fail("Exception was not thrown");
-    }
-
-    /**
-     * @coversNothing
-     */
-    public function testGenerateRawErrorsWhenPassedNonArray()
-    {
-        try {
-            $this->generator->generateRaw('test', 'nope');
-        }
-        catch(\PHPUnit_Framework_Exception $e) {
-            $this->assertStringStartsWith(
-                'Argument 2 passed to Aura\\Router\\Generator::generateRaw() must be of the type array, string given',
-                $e->getMessage()
-            );
-            return;
-        }
-
-        $this->fail("Exception was not thrown");
-    }
 }


### PR DESCRIPTION
It was pointed out in #131 that the documentation for the new feature passed in a string, and I realized that I had copied from the previous example.

While I updated the docs, I also figured it would may be a good idea to add the array type hint for the generate and generateRaw methods on the Generator. Currently any data can be passed in for the $data parameter, which will cause warnings when build is called due to using array_merge. 

I'm not sure if this a BC break or not, I can generate a PR for just the docs if that is better?
