### PR TITLE
Compatibility with PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require-dev": {
-        "zendframework/zend-diactoros": "~1.0",
+        "laminas/laminas-diactoros": "~2.2",
         "phpunit/phpunit": "~5.7 || ~4.8"
     },
     "autoload-dev": {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -147,6 +147,8 @@ class Generator
      *
      * @param bool $raw Leave the data unencoded?
      *
+     * @throws Exception\RouteNotFound
+     *
      * @return string
      *
      */

--- a/src/Map.php
+++ b/src/Map.php
@@ -201,6 +201,10 @@ class Map implements IteratorAggregate
      *
      * @param mixed $handler The route leads to this handler.
      *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
+     *
      * @return Route The newly-added route object.
      *
      */
@@ -224,6 +228,10 @@ class Map implements IteratorAggregate
      *
      * @param mixed $handler The route leads to this handler.
      *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
+     *
      * @return Route The newly-added route object.
      *
      */
@@ -243,6 +251,10 @@ class Map implements IteratorAggregate
      * @param string $path The route path.
      *
      * @param mixed $handler The route leads to this handler.
+     *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
      *
      * @return Route The newly-added route object.
      *
@@ -264,6 +276,10 @@ class Map implements IteratorAggregate
      *
      * @param mixed $handler The route leads to this handler.
      *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
+     *
      * @return Route The newly-added route object.
      *
      */
@@ -283,6 +299,10 @@ class Map implements IteratorAggregate
      * @param string $path The route path.
      *
      * @param mixed $handler The route leads to this handler.
+     *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
      *
      * @return Route The newly-added route object.
      *
@@ -304,6 +324,10 @@ class Map implements IteratorAggregate
      *
      * @param mixed $handler The route leads to this handler.
      *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
+     *
      * @return Route The newly-added route object.
      *
      */
@@ -324,6 +348,10 @@ class Map implements IteratorAggregate
      *
      * @param mixed $handler The route leads to this handler.
      *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
+     *
      * @return Route The newly-added route object.
      *
      */
@@ -343,6 +371,10 @@ class Map implements IteratorAggregate
      * @param string $path The route path.
      *
      * @param mixed $handler The route leads to this handler.
+     *
+     * @throws Exception\ImmutableProperty
+     *
+     * @throws Exception\RouteAlreadyExists
      *
      * @return Route The newly-added route object.
      *
@@ -366,6 +398,8 @@ class Map implements IteratorAggregate
      * @param callable $callable A callable that uses the Map to add new
      * routes. Its signature is `function (\Aura\Router\Map $map)`; $this
      * Map instance will be passed to the callable.
+     *
+     * @throws Exception\ImmutableProperty
      *
      * @return void
      *

--- a/src/Map.php
+++ b/src/Map.php
@@ -108,6 +108,7 @@ class Map implements IteratorAggregate
      * @return ArrayIterator
      *
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->routes);

--- a/src/Rule/RuleIterator.php
+++ b/src/Rule/RuleIterator.php
@@ -89,6 +89,7 @@ class RuleIterator implements Iterator
      * @return RuleInterface
      *
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $rule = current($this->rules);
@@ -117,6 +118,7 @@ class RuleIterator implements Iterator
      * @return mixed
      *
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->rules);
@@ -126,9 +128,10 @@ class RuleIterator implements Iterator
      *
      * Iterator: moves the iterator forward to the next rule.
      *
-     * @return null
+     * @return void
      *
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->rules);
@@ -141,6 +144,7 @@ class RuleIterator implements Iterator
      * @return null
      *
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->rules);
@@ -153,6 +157,7 @@ class RuleIterator implements Iterator
      * @return bool
      *
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return current($this->rules) !== false;


### PR DESCRIPTION
See https://www.php.net/manual/tr/migration81.incompatible.php

> Most non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation. In case the return type cannot be declared for an overriding method due to PHP cross-version compatibility concerns, a `#[ReturnTypeWillChange]` attribute can be added to silence the deprecation notice. 

Since we cannot type-hint the return value (for compatibility with older versions of PHP), this PR adds the attribute instead.