### PR TITLE
feature: Add FastRoute format for Route declaration

### DIFF
--- a/src/Rule/Path.php
+++ b/src/Rule/Path.php
@@ -20,6 +20,9 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 class Path implements RuleInterface
 {
+    /** https://github.com/nikic/FastRoute/blob/master/src/RouteParser/Std.php */
+    const REGEX = '#\{\s*([a-zA-Z_][a-zA-Z0-9_-]*)\s*(?::\s*([^{}]*(?:\{(?-1)\}[^{}]*)*))?\}#';
+    const OPT_REGEX = '#{\s*/\s*([a-z][a-zA-Z0-9_-]*\s*:*\s*[^{}]*,*)}#';
     /**
      *
      * Use this Route to build the regex.
@@ -158,12 +161,10 @@ class Path implements RuleInterface
      * Expands optional attributes in the regex from ``{/foo,bar,baz}` to
      * `(/{foo}(/{bar}(/{baz})?)?)?`.
      *
-     * @return null
-     *
      */
     protected function setRegexOptionalAttributes()
     {
-        preg_match('#{/([a-z][a-zA-Z0-9_,]*)}#', $this->regex, $matches);
+        preg_match(self::OPT_REGEX, $this->regex, $matches);
         if ($matches) {
             $repl = $this->getRegexOptionalAttributesReplacement($matches[1]);
             $this->regex = str_replace($matches[0], $repl, $this->regex);
@@ -218,19 +219,17 @@ class Path implements RuleInterface
      * Expands attribute names in the regex to named subpatterns; adds default
      * `null` values for attributes without defaults.
      *
-     * @return null
-     *
      */
     protected function setRegexAttributes()
     {
-        $find = '#{([a-z][a-zA-Z0-9_]*)}#';
         $attributes = $this->route->attributes;
         $newAttributes = [];
-        preg_match_all($find, $this->regex, $matches, PREG_SET_ORDER);
+        preg_match_all(self::REGEX, $this->regex, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {
             $name = $match[1];
-            $subpattern = $this->getSubpattern($name);
-            $this->regex = str_replace("{{$name}}", $subpattern, $this->regex);
+            $token = isset($match[2]) ? $match[2] : null;
+            $subpattern = $this->getSubpattern($name, $token);
+            $this->regex = str_replace($match[0], $subpattern, $this->regex);
             if (! isset($attributes[$name])) {
                 $newAttributes[$name] = null;
             }
@@ -243,15 +242,21 @@ class Path implements RuleInterface
      * Returns a named subpattern for an attribute name.
      *
      * @param string $name The attribute name.
+     * @param string|null $token The pattern FastRoute format from route
      *
      * @return string The named subpattern.
      *
      */
-    protected function getSubpattern($name)
+    protected function getSubpattern($name, $token = null)
     {
         // is there a custom subpattern for the name?
         if (isset($this->route->tokens[$name]) && is_string($this->route->tokens[$name])) {
-            return "(?P<{$name}>{$this->route->tokens[$name]})";
+            // if $token is null use route token
+            $token = $token ?: $this->route->tokens[$name];
+        }
+
+        if ($token) {
+            return "(?P<{$name}>{$token})";
         }
 
         // use a default subpattern
@@ -261,8 +266,6 @@ class Path implements RuleInterface
     /**
      *
      * Adds a wildcard subpattern to the end of the regex.
-     *
-     * @return null
      *
      */
     protected function setRegexWildcard()

--- a/tests/Rule/PathTest.php
+++ b/tests/Rule/PathTest.php
@@ -47,7 +47,29 @@ class PathTest extends AbstractRuleTest
         $this->assertEquals($expect, $route->attributes);
     }
 
-    public function testIsMatchOnDefaultAndDefinedSubpatterns()
+    public function testIsMatchOnDynamicPathWithFastRouteFormat()
+    {
+        $route = $this->newRoute(
+            '/{controller:[a-zA-Z][a-zA-Z0-9_-]+}' .
+            '/{action:[a-zA-Z][a-zA-Z0-9_-]+}' .
+            '/{id:[0-9]+}' .
+            '{format: (\.[^/]+)?}'
+        );
+
+        $request = $this->newRequest('/foo/bar/42');
+
+        $this->assertIsMatch($request, $route);
+
+        $expect = [
+            'controller' => 'foo',
+            'action' => 'bar',
+            'id' => '42',
+            'format' => null,
+        ];
+        $this->assertEquals($expect, $route->attributes);
+    }
+
+    public function testIsMatchOnDefaultAndDefinedSubPatterns()
     {
         $route = $this->newRoute('/{controller}/{action}/{id}{format}')
             ->tokens([
@@ -67,11 +89,53 @@ class PathTest extends AbstractRuleTest
         $this->assertSame($expect, $route->attributes);
     }
 
-    public function testIsMatchOnDefaultAndCustomSubpatterns()
+    public function testIsMatchOnDefaultAndDefinedSubPatternsWithFastRouteFormat()
+    {
+        $route = $this->newRoute('/{controller}'.
+            '/{action: (browse|read|edit|add|delete)}' .
+            '/{id: \d+}' .
+            '{format: (\.[^/]+)?}'
+        );
+
+        $request = $this->newRequest('/any-value/read/42');
+        $this->assertIsMatch($request, $route);
+        $expect = [
+            'controller' => 'any-value',
+            'action' => 'read',
+            'id' => '42',
+            'format' => null,
+        ];
+        $this->assertSame($expect, $route->attributes);
+    }
+
+    public function testIsMatchOnDefaultAndCustomSubPatterns()
     {
         $route = $this->newRoute('/assets/{file}\.{semver}{format}')
             ->tokens([
                 'file' => '([\w\d\-\_]+)',
+                'semver' => function ($semver, $route, $request) {
+                    if ($semver === '1.3.1') {
+                        return true;
+                    }
+                    return false;
+                },
+                'format' => '(\.[^/]+)',
+            ]);
+
+        $request = $this->newRequest('/assets/any-file.1.3.1.zip');
+        $this->assertIsMatch($request, $route);
+        $expect = [
+            'file' => 'any-file',
+            'semver' => '1.3.1',
+            'format' => '.zip'
+        ];
+        $this->assertSame($expect, $route->attributes);
+    }
+
+    public function testIsMatchOnDefaultAndCustomSubPatternsWithFastRouteForFile()
+    {
+        $route = $this->newRoute('/assets/{file: [\w\d\-\_]+}\.{semver}{format}')
+            ->tokens([
                 'semver' => function ($semver, $route, $request) {
                     if ($semver === '1.3.1') {
                         return true;
@@ -166,9 +230,58 @@ class PathTest extends AbstractRuleTest
         $this->assertIsNotMatch($request, $route);
     }
 
+    public function testIsMatchOnOptionalAttributesWithSomeFastRouteFormat()
+    {
+        $route = $this->newRoute('/foo/{bar:[a-zA-Z]+}{/baz:[a-zA-Z]+,dib,zim}');
+
+        // not enough attributes
+        $request = $this->newRequest('/foo');
+        $this->assertIsNotMatch($request, $route);
+
+        // just enough attributes
+        $request = $this->newRequest('/foo/bar');
+        $this->assertIsMatch($request, $route);
+
+        // optional attribute 1
+        $request = $this->newRequest('/foo/bar/baz');
+        $this->assertIsMatch($request, $route);
+
+        // optional attribute 2
+        $request = $this->newRequest('/foo/bar/baz/dib');
+        $this->assertIsMatch($request, $route);
+
+        // optional attribute 3
+        $request = $this->newRequest('/foo/bar/baz/dib/zim');
+        $this->assertIsMatch($request, $route);
+
+        // too many attributes
+        $request = $this->newRequest('/foo/bar/baz/dib/zim/gir');
+        $this->assertIsNotMatch($request, $route);
+    }
+
     public function testIsMatchOnOnlyOptionalAttributes()
     {
         $route = $this->newRoute('{/foo,bar,baz}');
+
+        $request = $this->newRequest('/');
+        $this->assertIsMatch($request, $route);
+
+        $request = $this->newRequest('/foo');
+        $this->assertIsMatch($request, $route);
+
+        $request = $this->newRequest('/foo/bar');
+        $this->assertIsMatch($request, $route);
+
+        $request = $this->newRequest('/foo/bar/baz');
+        $this->assertIsMatch($request, $route);
+
+        $request = $this->newRequest('/foo/bar/baz/dib');
+        $this->assertIsNotMatch($request, $route);
+    }
+
+    public function testIsMatchOnOnlyOptionalAttributesWithSomeFastRouteFormat()
+    {
+        $route = $this->newRoute('{/foo:[a-zA-Z]+,bar,baz:[a-zA-Z]+}');
 
         $request = $this->newRequest('/');
         $this->assertIsMatch($request, $route);

--- a/tests/Rule/PathTest.php
+++ b/tests/Rule/PathTest.php
@@ -69,6 +69,60 @@ class PathTest extends AbstractRuleTest
         $this->assertEquals($expect, $route->attributes);
     }
 
+    public function testIsMatchOnDynamicPathWithFastRouteFormatAndRouteTokens()
+    {
+        $route = $this->newRoute(
+            '/{controller}' .
+            '/{action:[a-zA-Z][a-zA-Z0-9_-]+}' .
+            '/{id:[0-9]+}' .
+            '{format: (\.[^/]+)?}'
+        ) ->tokens([
+            'controller' => '([a-zA-Z][a-zA-Z0-9_-]+)',
+            'action' => '([a-zA-Z][a-zA-Z0-9_-]+)',
+            'id' => '([0-9]+)',
+            'format' => '(\.[^/]+)?',
+        ]);;
+
+        $request = $this->newRequest('/foo/bar/42');
+
+        $this->assertIsMatch($request, $route);
+
+        $expect = [
+            'controller' => 'foo',
+            'action' => 'bar',
+            'id' => '42',
+            'format' => null,
+        ];
+        $this->assertEquals($expect, $route->attributes);
+    }
+
+    public function testIsMatchOnDynamicPathWithFastRouteFormatAndFailedRouteTokens()
+    {
+        $route = $this->newRoute(
+            '/{controller:[a-zA-Z][a-zA-Z0-9_-]+}' .
+            '/{action:[a-zA-Z][a-zA-Z0-9_-]+}' .
+            '/{id:[0-9]+}' .
+            '{format: (\.[^/]+)?}'
+        ) ->tokens([
+            'controller' => '(\d+)',
+            'action' => '([a-zA-Z][a-zA-Z0-9_-]+)',
+            'id' => '([0-9]+)',
+            'format' => '(\.[^/]+)?',
+        ]);;
+
+        $request = $this->newRequest('/foo/bar/42');
+
+        $this->assertIsMatch($request, $route);
+
+        $expect = [
+            'controller' => 'foo',
+            'action' => 'bar',
+            'id' => '42',
+            'format' => null,
+        ];
+        $this->assertEquals($expect, $route->attributes);
+    }
+
     public function testIsMatchOnDefaultAndDefinedSubPatterns()
     {
         $route = $this->newRoute('/{controller}/{action}/{id}{format}')


### PR DESCRIPTION
Use FastRoute Regex when declare route

Probably better to create build-in Regex for this feature, but it work fine as is.

All added tests works without breakdown.