### PR TITLE
faster lookups instead of nested loops

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -187,26 +187,28 @@ class Generator
     protected function buildTokenReplacements()
     {
         preg_match_all(self::REGEX, $this->url, $matches, PREG_SET_ORDER);
+        $data_keys = array_flip(array_keys($this->data));
+
         foreach ($matches as $match) {
             $name = $match[1];
-            foreach ($this->data as $key => $val) {
-                if ($key === $name) {
-                    $token = isset($match[2]) ? $match[2] : null;
-                    if (isset($this->route->tokens[$name]) && is_string($this->route->tokens[$name])) {
-                        // if $token is null use route token
-                        $token = $token ?: $this->route->tokens[$name];
-                    }
-                    if ($token) {
-                        if (!preg_match('~^' . $token . '$~', (string)$val)) {
-                            throw new \RuntimeException(sprintf(
-                                'Parameter value for [%s] did not match the regex `%s`',
-                                $name,
-                                $token
-                            ));
-                        }
-                    }
-                    $this->repl[$match[0]] = $this->encode($val);
+
+            if (isset($data_keys[$name])) {
+                $val = $this->data[$name];
+                $token = isset($match[2]) ? $match[2] : null;
+                if (isset($this->route->tokens[$name]) && is_string($this->route->tokens[$name])) {
+                    // if $token is null use route token
+                    $token = $token ?: $this->route->tokens[$name];
                 }
+                if ($token) {
+                    if (!preg_match('~^' . $token . '$~', (string)$val)) {
+                        throw new \RuntimeException(sprintf(
+                            'Parameter value for [%s] did not match the regex `%s`',
+                            $name,
+                            $token
+                        ));
+                    }
+                }
+                $this->repl[$match[0]] = $this->encode($val);
             }
         }
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -187,12 +187,11 @@ class Generator
     protected function buildTokenReplacements()
     {
         preg_match_all(self::REGEX, $this->url, $matches, PREG_SET_ORDER);
-        $data_keys = array_flip(array_keys($this->data));
 
         foreach ($matches as $match) {
             $name = $match[1];
 
-            if (isset($data_keys[$name])) {
+            if (isset($this->data[$name])) {
                 $val = $this->data[$name];
                 $token = isset($match[2]) ? $match[2] : null;
                 if (isset($this->route->tokens[$name]) && is_string($this->route->tokens[$name])) {


### PR DESCRIPTION
I try to optimize the performance of the buildTokenReplacements() method by using array_flip for faster lookups instead of nested loops.